### PR TITLE
Add a hint about the non-standard arduino spi pins

### DIFF
--- a/examples/X_NUCLEO_IHM02A1_HelloWorld/X_NUCLEO_IHM02A1_HelloWorld.ino
+++ b/examples/X_NUCLEO_IHM02A1_HelloWorld/X_NUCLEO_IHM02A1_HelloWorld.ino
@@ -139,6 +139,7 @@ void setup()
 {
     /*----- Initialization. -----*/
 
+    /* Please verify your board has these spi pins */
     /* Initializing SPI bus. */
     dev_spi = new SPIClass(D11, D12, D3);
     SerialPort.begin(115200);


### PR DESCRIPTION
To prevent issues like Arduino_Core_STM32#455, since some boards like the Nucleo F429ZI don't have SPI CLK at D3